### PR TITLE
Portal <> Ghost 4.0

### DIFF
--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -188,7 +188,7 @@ export default class Notification extends React.Component {
         const type = this.state.type;
         const deleteParams = [];
         if (['signin', 'signup'].includes(type)) {
-            deleteParams.push('portal-action', 'success');
+            deleteParams.push('action', 'success');
         } else if (['stripe:checkout'].includes(type)) {
             deleteParams.push('stripe');
         }

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -51,7 +51,7 @@ export default function NotificationParser({billingOnly = false} = {}) {
         return null;
     }
     const qsParams = new URLSearchParams(qs);
-    const action = qsParams.get('portal-action');
+    const action = qsParams.get('action');
     const successStatus = qsParams.get('success');
     const stripeStatus = qsParams.get('stripe');
     let notificationData = null;


### PR DESCRIPTION
WIP PR to keep track of Portal changes for Ghost 4.0

- Removed `portal-action` param in favor of action
  -  Going forward, we want to keep a single universal action source so the Ghost core doesn't have to know about portal specific actions