### PR TITLE
Updated to handle invite only setting

### DIFF
--- a/src/components/pages/SignupPage.js
+++ b/src/components/pages/SignupPage.js
@@ -5,7 +5,7 @@ import PlansSection from '../common/PlansSection';
 import InputForm from '../common/InputForm';
 import {ValidateInputForm} from '../../utils/form';
 import CalculateDiscount from '../../utils/discount';
-import {getSitePlans, hasOnlyFreePlan} from '../../utils/helpers';
+import {getSitePlans, hasOnlyFreePlan, isInviteOnlySite} from '../../utils/helpers';
 import {ReactComponent as InvitationIcon} from '../../images/icons/invitation.svg';
 
 const React = require('react');
@@ -405,7 +405,7 @@ class SignupPage extends React.Component {
         const fields = this.getInputFields({state: this.state});
         const {site, pageQuery} = this.context;
         const availablePlans = getSitePlans({site, pageQuery});
-        if (availablePlans.length === 0) {
+        if (availablePlans.length === 0 || isInviteOnlySite({site})) {
             return (
                 <section>
                     <div className='gh-portal-section'>

--- a/src/utils/fixtures.js
+++ b/src/utils/fixtures.js
@@ -11,6 +11,7 @@ export const site = {
         currency: 'USD'
     },
     allow_self_signup: true,
+    members_signup_access: 'all',
     is_stripe_configured: true,
     portal_button: true,
     portal_name: true,

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -106,6 +106,10 @@ export function capitalize(str) {
     return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
+export function isInviteOnlySite({site = {}}) {
+    return site && site.members_signup_access === 'invite';
+}
+
 export function getSitePlans({site = {}, includeFree = true, pageQuery} = {}) {
     const {
         plans,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/579

A new setting `members_signup_access` can be set to `invite` by the site owner which explicitly makes Portal to behave invite only, this change updates Portal to handle the setting