### PR TITLE
Prevent upgrade cta appearing on accounts that have no upgrade option.

### DIFF
--- a/src/components/pages/AccountHomePage.js
+++ b/src/components/pages/AccountHomePage.js
@@ -313,7 +313,7 @@ const AccountWelcome = () => {
     const {member, site} = useContext(AppContext);
     const {is_stripe_configured: isStripeConfigured} = site;
 
-    if (!isStripeConfigured) {
+    if (!isStripeConfigured || hasOnlyFreePlan({site})) {
         return null;
     }
     const subscription = getMemberSubscription({member});


### PR DESCRIPTION
When first configuring Portal, it is reasonable and straight-forward to connect a Stripe account as instructed, but then disable the paid tiers to delay presenting paid memberships until the site is mature enough to warrant paid memberships.

This results in a very functional Portal, which prompts for, processes and accepts free membership. After logging into a free account however, the Portal displays a call-to-action paragraph encouraging the user to upgrade to a paid account. Obviously this is confusing for the user, given that there are no paid options.

The code already performs a series of checks to ensure it is worth making a call to action. Given that a function to check for the existence of paid accounts is also provided, it seems a simple oversight that it is not included in the checks. This PR adds that check.

The result is no change for sites that have paid memberships, or do not have Stripe configured. But if the only membership plan is free, then the cta text is not added to the page, just as it would not be if Stripe was not configured or the subscription was complimentary or cancelled.