### PR TITLE
Enable alternate Ghost site via `data-site-url`

### DIFF
--- a/src/data-attributes.js
+++ b/src/data-attributes.js
@@ -28,6 +28,11 @@ function handleDataAttributes({siteUrl, site, member}) {
             if (form.dataset.membersForm) {
                 emailType = form.dataset.membersForm;
             }
+            
+            // Use the portal of an alternate Ghost site if specified
+            if (form.dataset.siteUrl) {
+                siteUrl = form.dataset.siteUrl;
+            }
 
             form.classList.add('loading');
             fetch(`${siteUrl}/members/api/send-magic-link/`, {


### PR DESCRIPTION
It seems you can't use another site's portal if you're already on a Ghost site, so this would be useful in cases where you have a separate Ghost installation for your mailing list.