### PR TITLE
Added explicit magic link type and improved login error handling

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,3 +1,4 @@
+import {HumanReadableError} from './utils/errors';
 import {createPopupNotification, getMemberEmail, getMemberName, getProductCadenceFromPrice, removePortalLinkFromUrl} from './utils/helpers';
 
 function switchPage({data, state}) {
@@ -77,7 +78,7 @@ async function signout({api, state}) {
 
 async function signin({data, api, state}) {
     try {
-        await api.member.sendMagicLink(data);
+        await api.member.sendMagicLink({...data, emailType: 'signin'});
         return {
             page: 'magiclink',
             lastPage: 'signin'
@@ -87,7 +88,7 @@ async function signin({data, api, state}) {
             action: 'signin:failed',
             popupNotification: createPopupNotification({
                 type: 'signin:failed', autoHide: false, closeable: true, state, status: 'error',
-                message: 'Failed to log in, please try again'
+                message: HumanReadableError.getMessageFromError(e, 'Failed to log in, please try again')
             })
         };
     }
@@ -97,7 +98,7 @@ async function signup({data, state, api}) {
     try {
         let {plan, tierId, cadence, email, name, newsletters, offerId} = data;
         if (plan.toLowerCase() === 'free') {
-            await api.member.sendMagicLink(data);
+            await api.member.sendMagicLink({emailType: 'signup', ...data});
         } else {
             if (tierId && cadence) {
                 await api.member.checkoutPlan({plan, tierId, cadence, email, name, newsletters, offerId});

--- a/src/components/pages/SigninPage.js
+++ b/src/components/pages/SigninPage.js
@@ -32,7 +32,7 @@ export default class SigninPage extends React.Component {
             return {
                 errors: ValidateInputForm({fields: this.getInputFields({state})})
             };
-        }, () => {
+        }, async () => {
             const {email, errors} = this.state;
             const hasFormErrors = (errors && Object.values(errors).filter(d => !!d).length > 0);
             if (!hasFormErrors) {

--- a/src/data-attributes.js
+++ b/src/data-attributes.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-
 import {getQueryPrice, getUrlHistory} from './utils/helpers';
+const {HumanReadableError} = require('./utils/errors');
 
 export function formSubmitHandler({event, form, errorEl, siteUrl, submitHandler}) {
     form.removeEventListener('submit', submitHandler);
@@ -51,11 +51,16 @@ export function formSubmitHandler({event, form, errorEl, siteUrl, submitHandler}
         if (res.ok) {
             form.classList.add('success');
         } else {
-            if (errorEl) {
-                errorEl.innerText = 'There was an error sending the email, please try again';
-            }
-            form.classList.add('error');
+            return HumanReadableError.fromApiResponse(res).then((e) => {
+                throw e;
+            });
         }
+    }).catch((err) => {
+        if (errorEl) {
+            // This theme supports a custom error element
+            errorEl.innerText = HumanReadableError.getMessageFromError(err, 'There was an error sending the email, please try again');
+        }
+        form.classList.add('error');
     });
 }
 

--- a/src/data-attributes.js
+++ b/src/data-attributes.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import {getQueryPrice, getUrlHistory} from './utils/helpers';
-const {HumanReadableError} = require('./utils/errors');
+import {HumanReadableError} from './utils/errors';
 
 export function formSubmitHandler({event, form, errorEl, siteUrl, submitHandler}) {
     form.removeEventListener('submit', submitHandler);

--- a/src/tests/SigninFlow.test.js
+++ b/src/tests/SigninFlow.test.js
@@ -141,7 +141,8 @@ describe('Signin', () => {
 
             fireEvent.click(submitButton);
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com'
+                email: 'jamie@example.com',
+                emailType: 'signin'
             });
 
             const magicLink = await within(popupIframeDocument).findByText(/sent you a login link/i);
@@ -166,7 +167,8 @@ describe('Signin', () => {
 
             fireEvent.click(submitButton);
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com'
+                email: 'jamie@example.com',
+                emailType: 'signin'
             });
 
             const magicLink = await within(popupIframeDocument).findByText(/sent you a login link/i);
@@ -191,7 +193,8 @@ describe('Signin', () => {
 
             fireEvent.click(submitButton);
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com'
+                email: 'jamie@example.com',
+                emailType: 'signin'
             });
 
             const magicLink = await within(popupIframeDocument).findByText(/sent you a login link/i);
@@ -230,7 +233,8 @@ describe('Signin', () => {
 
             fireEvent.click(submitButton);
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com'
+                email: 'jamie@example.com',
+                emailType: 'signin'
             });
 
             const magicLink = await within(popupIframeDocument).findByText(/sent you a login link/i);
@@ -255,7 +259,8 @@ describe('Signin', () => {
 
             fireEvent.click(submitButton);
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com'
+                email: 'jamie@example.com',
+                emailType: 'signin'
             });
 
             const magicLink = await within(popupIframeDocument).findByText(/sent you a login link/i);
@@ -280,7 +285,8 @@ describe('Signin', () => {
 
             fireEvent.click(submitButton);
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
-                email: 'jamie@example.com'
+                email: 'jamie@example.com',
+                emailType: 'signin'
             });
 
             const magicLink = await within(popupIframeDocument).findByText(/sent you a login link/i);

--- a/src/tests/SignupFlow.test.js
+++ b/src/tests/SignupFlow.test.js
@@ -208,6 +208,7 @@ describe('Signup', () => {
             fireEvent.click(chooseBtns[0]);
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
+                emailType: 'signup',
                 name: 'Jamie Larsen',
                 plan: 'free'
             });
@@ -242,6 +243,7 @@ describe('Signup', () => {
 
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
+                emailType: 'signup',
                 name: '',
                 plan: 'free'
             });
@@ -281,6 +283,7 @@ describe('Signup', () => {
 
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
+                emailType: 'signup',
                 name: 'Jamie Larsen',
                 plan: 'free'
             });
@@ -566,6 +569,7 @@ describe('Signup', () => {
             fireEvent.click(chooseBtns[0]);
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
+                emailType: 'signup',
                 name: 'Jamie Larsen',
                 plan: 'free'
             });
@@ -596,6 +600,7 @@ describe('Signup', () => {
 
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
+                emailType: 'signup',
                 name: '',
                 plan: 'free'
             });
@@ -632,6 +637,7 @@ describe('Signup', () => {
 
             expect(ghostApi.member.sendMagicLink).toHaveBeenLastCalledWith({
                 email: 'jamie@example.com',
+                emailType: 'signup',
                 name: 'Jamie Larsen',
                 plan: 'free'
             });

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,0 +1,34 @@
+class HumanReadableError extends Error {
+    /**
+     * Returns whether this response from the server is a human readable error and should be shown to the user.
+     * @param {Response} res
+     * @returns {HumanReadableError|undefined}
+     */
+    static async fromApiResponse(res) {
+        // Bad request + Too many requests
+        if (res.status === 400 || res.status === 429) {
+            try {
+                const json = await res.json();
+                if (json.errors && Array.isArray(json.errors) && json.errors.length > 0 && json.errors[0].message) {
+                    return new HumanReadableError(json.errors[0].message);
+                }
+            } catch (e) {
+                // Failed to decode: ignore
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Only output the message of an error if it is a human readable error and should be exposed to the user.
+     * Otherwise it returns a default generic message.
+     */
+    static getMessageFromError(error, defaultMessage) {
+        if (error instanceof HumanReadableError) {
+            return error.message;
+        }
+        return defaultMessage;
+    }
+}
+
+module.exports = {HumanReadableError};

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,4 +1,4 @@
-class HumanReadableError extends Error {
+export class HumanReadableError extends Error {
     /**
      * Returns whether this response from the server is a human readable error and should be shown to the user.
      * @param {Response} res
@@ -30,5 +30,3 @@ class HumanReadableError extends Error {
         return defaultMessage;
     }
 }
-
-module.exports = {HumanReadableError};

--- a/src/utils/test-utils.js
+++ b/src/utils/test-utils.js
@@ -15,7 +15,7 @@ const setupProvider = (context) => {
 };
 
 const customRender = (ui, {options = {}, overrideContext = {}} = {}) => {
-    const mockOnActionFn = jest.fn();
+    const mockOnActionFn = jest.fn().mockResolvedValue(undefined);
 
     const context = {
         site: testSite,


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/14508

This change is needed for https://github.com/TryGhost/Ghost/pull/15526

- Send the emailType parameter when requesting a magic link. This makes sure that we don't sign up a new member when we try to sign in.
- Improved error handling when logging in or signing up (now will show a proper error message from the backend, e.g. 'member does not exist').